### PR TITLE
Use git to determine if inside git repo

### DIFF
--- a/lua/git/utils.lua
+++ b/lua/git/utils.lua
@@ -31,7 +31,14 @@ function M.log(message)
 end
 
 function M.get_git_repo()
-  return M.run_git_cmd('git rev-parse --git-dir')
+  local dir = vim.fn.trim(M.run_git_cmd('git rev-parse --show-toplevel'))
+  local file = vim.fn.expand('%')
+
+  if file == "" or file == "." or dir == "" then
+    return ""
+  else
+    return dir
+  end
 end
 
 return M

--- a/lua/git/utils.lua
+++ b/lua/git/utils.lua
@@ -31,12 +31,7 @@ function M.log(message)
 end
 
 function M.get_git_repo()
-  local fpath = vim.api.nvim_buf_get_name(0)
-  if fpath == "" then
-    return ""
-  end
-
-  return vim.fn.finddir(".git/..", fpath .. ";")
+  return M.run_git_cmd('git rev-parse --git-dir')
 end
 
 return M


### PR DESCRIPTION
Mostly figured since this is a git-centric plugin using actual git to determine this would be sufficient.

```
09:58: [LTCJMZT:~/Projects/is_a_git_project]
 > git rev-parse --git-dir
.git
10:03: [LTCJMZT:~/Projects/is_a_git_project]
 > cd ..
10:03: [LTCJMZT:~/Projects]
 > git rev-parse --git-dir
fatal: not a git repository (or any of the parent directories): .git
10:03: [LTCJMZT:~/Projects]
```