### PR TITLE
Fix path xxx does not exist in HEAD during :GitDiff

### DIFF
--- a/lua/git/diff.lua
+++ b/lua/git/diff.lua
@@ -59,10 +59,14 @@ function M.open(base)
 
   diff_state.base_bufnr = vim.api.nvim_get_current_buf()
 
+  local cwd = vim.fn.getcwd() -- save current dir
+  vim.fn.chdir(git_root)
+  local path_relative_to_git_root = vim.fn.expand '%:.'
+  vim.fn.chdir(cwd) -- restore
   local file_content_cmd = "git -C "
-    .. git_root
-    .. string.format(" --literal-pathspecs --no-pager show %s:", base)
-    .. vim.fn.fnamemodify(vim.fn.expand "%", ":~:.")
+      .. git_root
+      .. string.format(" --literal-pathspecs --no-pager show %s:", base)
+      .. path_relative_to_git_root
 
   utils.jobstart(file_content_cmd, on_get_file_content_done)
 end


### PR DESCRIPTION
Previously if the current directory != git_root  `:GitDiff` will fail with: 

    [git] Error during running a job: fatal: path 'App.tsx' does not exist in 'HEAD'

This PR ensures that the path is calculated relative to the git root (not to the current directory). 

Step to reproduce the issue in the current main branch: 

```
cd /Users/ecerulm/tmp/my-app/src 
nvim App.tsx
:GitDiff
``` 

will execute `git -C /Users/ecerulm/tmp/my-app --literal-pathspecs --no-pager show HEAD:App.tsx`, where `HEAD:App.tsx` does not exist (it should be `HEAD:src/App.tsx`)




