### PR TITLE
feat: add GitBlame command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ require('git').setup({
 Eg: 
 `:Git checkout -b test`
 
+`:GitBlame` opens git blame window
+
 `:GitDiff` opens a new diff that compares against the current index. You can also provide any valid git rev to the command. Eg: `:GitDiff HEAD~2`
 
 `:GitDiffClose` close the git diff window

--- a/lua/git.lua
+++ b/lua/git.lua
@@ -33,6 +33,11 @@ local function config_keymaps()
 end
 
 local function config_commands()
+  vim.api.nvim_create_user_command("GitBlame", 'lua require("git.blame").blame()<CR>', {
+    bang = true,
+    nargs = "*",
+  })
+
   vim.api.nvim_create_user_command("GitCreatePullRequest", 'lua require("git.browse").create_pull_request(<f-args>)', {
     bang = true,
     nargs = "*",


### PR DESCRIPTION
Hi @dinhhuy258, thanks for your nice repo. This PR tries to add `GitBlame` command, it would be helpful as other vim git plugins usually have this command by default.