### PR TITLE
fix: not being able to open file in git repository

### DIFF
--- a/lua/git/browse.lua
+++ b/lua/git/browse.lua
@@ -36,6 +36,15 @@ local function get_git_remote_url()
     git_remote_url = "https://" .. git_remote_url
   end
 
+  if utils.starts_with(git_remote_url, "ssh://") then
+    git_remote_url = git_remote_url:sub(#"ssh://" + 1)
+    git_remote_url = "https://" .. git_remote_url
+  end
+
+  if utils.starts_with(git_remote_url, "github.com:") then
+    git_remote_url = "https://" .. git_remote_url
+  end
+
   git_remote_url = git_remote_url:gsub("com:", "com/")
 
   if utils.end_with(git_remote_url, ".git") then


### PR DESCRIPTION
Fixed the following cases where `git remote get-url origin` did not open the repository in a browser because the `git_remote_url` did not contain "https://".

```shell
❯ git remote get-url origin
github.com:xxxx/yyyy

❯ git remote get-url origin
ssh://git@github.com/xxxx/yyyy
```