### PR TITLE
git/browse: handle SSH URLs

### DIFF
--- a/lua/git/browse/git_server_factory.lua
+++ b/lua/git/browse/git_server_factory.lua
@@ -20,6 +20,9 @@ local function _get_git_remote_url()
   if remote_url:find "^git@" then
     git_server, git_path = remote_url:match "^git@([^:/]+):(.+)"
     git_server = "https://" .. git_server
+  elseif remote_url:find "^ssh://git@" then
+    git_server, git_path = remote_url:match "^ssh://git@([^:/]+)/(.+)"
+    git_server = "https://" .. git_server
   else
     git_server, git_path = remote_url:match "^(https?://[^/]+)/(.+)"
   end


### PR DESCRIPTION
Adds a case to handle SSH URLs like `ssh://git@github.com/seruman/some-repo.git` which was not matched previously.