### PR TITLE
feat(winbar): add winbar option

### DIFF
--- a/lua/git/blame.lua
+++ b/lua/git/blame.lua
@@ -27,6 +27,9 @@ local function create_blame_win()
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
   vim.api.nvim_buf_set_option(buf, "filetype", "git.nvim")
   vim.api.nvim_buf_set_option(buf, "buflisted", false)
+  if config.winbar then
+    vim.api.nvim_set_option_value("winbar", "Git Blame", { scope = "local", win = win })
+  end
 
   vim.api.nvim_win_set_option(win, "number", false)
   vim.api.nvim_win_set_option(win, "foldcolumn", "0")

--- a/lua/git/cmd.lua
+++ b/lua/git/cmd.lua
@@ -1,3 +1,4 @@
+local config = require("git.config").config
 local utils = require "git.utils"
 
 local M = {}
@@ -14,6 +15,9 @@ local function create_cmd_win()
   vim.api.nvim_buf_set_option(buf, "swapfile", false)
   vim.api.nvim_buf_set_option(buf, "buflisted", false)
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  if config.winbar then
+    vim.api.nvim_buf_set_option_value("winbar", "Git CMD", { scope = 'local', win = win })
+  end
 
   vim.api.nvim_win_set_option(win, "wrap", false)
   vim.api.nvim_win_set_option(win, "number", false)

--- a/lua/git/config.lua
+++ b/lua/git/config.lua
@@ -21,6 +21,7 @@ local default_cfg = {
   },
   target_branch = "master",
   private_gitlabs = {},
+  winbar = false
 }
 
 function M.is_private_gitlab(host)

--- a/lua/git/diff.lua
+++ b/lua/git/diff.lua
@@ -1,3 +1,4 @@
+local config = require("git.config").config
 local utils = require "git.utils"
 local git = require "git.utils.git"
 
@@ -22,6 +23,9 @@ local function on_get_file_content_done(lines)
   vim.api.nvim_buf_set_option(buf, "bufhidden", "delete")
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
   vim.api.nvim_command "autocmd BufDelete <buffer> lua require('git.diff').on_diff_quit()"
+  if config.winbar then
+    vim.api.nvim_set_option_value("winbar", "Git Diff", { scope = 'local', win = win })
+  end
 end
 
 function M.on_diff_quit()

--- a/lua/git/revert.lua
+++ b/lua/git/revert.lua
@@ -1,3 +1,4 @@
+local config = require("git.config").config
 local utils = require "git.utils"
 local git = require "git.utils.git"
 
@@ -22,6 +23,9 @@ local function create_revert_window()
   vim.api.nvim_win_set_option(win, "wrap", false)
   vim.api.nvim_win_set_option(win, "number", false)
   vim.api.nvim_win_set_option(win, "list", false)
+  if config.winbar then
+    vim.api.nvim_set_option_value("winbar", "Git Revert", {scope = 'local', win = wint })
+  end
 
   -- Keymaps
   local options = {


### PR DESCRIPTION
This commit resolves the issue in #19.  I originally posted just without the option setting. Once the request had been accepted, it was then requested reversion by the user who probably doesn't use the winbar feature and thus doesn't feel any inconvenience in Git Blame/Git Diff.

set winbar = true to pad the "winbar" position in Git blame window

