### PR TITLE
Fixed when the directory contains parentheses bug

### DIFF
--- a/lua/git/blame.lua
+++ b/lua/git/blame.lua
@@ -221,7 +221,7 @@ function M.blame_quit()
 end
 
 function M.blame()
-  local fpath = vim.api.nvim_buf_get_name(0)
+  local fpath = utils.escape_parentheses(vim.api.nvim_buf_get_name(0))
   if fpath == "" or fpath == nil then
     return
   end

--- a/lua/git/diff.lua
+++ b/lua/git/diff.lua
@@ -24,7 +24,7 @@ local function on_get_file_content_done(lines)
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
   vim.api.nvim_command "autocmd BufDelete <buffer> lua require('git.diff').on_diff_quit()"
   if config.winbar then
-    vim.api.nvim_set_option_value("winbar", "Git Diff", { scope = 'local', win = win })
+    vim.api.nvim_set_option_value("winbar", "Git Diff", { scope = "local", win = win })
   end
 end
 
@@ -47,7 +47,7 @@ function M.open(base)
     return
   end
 
-  local fpath = vim.api.nvim_buf_get_name(0)
+  local fpath = utils.escape_parentheses(vim.api.nvim_buf_get_name(0))
   if fpath == "" or fpath == nil then
     return
   end

--- a/lua/git/diff.lua
+++ b/lua/git/diff.lua
@@ -61,7 +61,6 @@ function M.open(base)
   local cwd = vim.fn.getcwd() -- save current dir
   vim.fn.chdir(git_root)
   local path_relative_to_git_root = utils.escape_parentheses(vim.fn.expand "%:.")
-
   vim.fn.chdir(cwd) -- restore
   local file_content_cmd = "git -C "
     .. git_root

--- a/lua/git/diff.lua
+++ b/lua/git/diff.lua
@@ -47,11 +47,6 @@ function M.open(base)
     return
   end
 
-  local fpath = utils.escape_parentheses(vim.api.nvim_buf_get_name(0))
-  if fpath == "" or fpath == nil then
-    return
-  end
-
   local git_root = git.get_git_repo()
   if git_root == "" then
     return
@@ -65,7 +60,8 @@ function M.open(base)
 
   local cwd = vim.fn.getcwd() -- save current dir
   vim.fn.chdir(git_root)
-  local path_relative_to_git_root = vim.fn.expand "%:."
+  local path_relative_to_git_root = utils.escape_parentheses(vim.fn.expand "%:.")
+
   vim.fn.chdir(cwd) -- restore
   local file_content_cmd = "git -C "
     .. git_root

--- a/lua/git/utils/git.lua
+++ b/lua/git/utils/git.lua
@@ -44,7 +44,7 @@ function M.get_current_branch_name()
 end
 
 function M.get_repo_info()
-  local cwd = vim.fn.expand "%:p:h"
+  local cwd = utils.escape_parentheses(vim.fn.expand "%:p:h")
   local data = vim.fn.trim(
     M.run_git_cmd("cd " .. cwd .. " && git --no-pager rev-parse --show-toplevel --absolute-git-dir --abbrev-ref HEAD")
   )

--- a/lua/git/utils/init.lua
+++ b/lua/git/utils/init.lua
@@ -17,6 +17,13 @@ function M.split(s, delimiter)
   return result
 end
 
+function M.escape_parentheses(str)
+  if type(str) ~= "string" then
+    return ""
+  end
+  return string.gsub(str, "%(", "\\("):gsub("%)", "\\)")
+end
+
 function M.handle_job_data(data)
   if not data then
     return nil


### PR DESCRIPTION
Fixed a bug `git diff` and `git blame` didn't work if the directory name contained parentheses.
The cause of the problem was that escaping wasn't working properly for directories containing parentheses.

It has a special meaning in frameworks such as Next.js that the directory containing parentheses.

https://nextjs.org/docs/app/building-your-application/routing/route-groups#examples

## Fixed result

### git blame

<img width="1436" alt="スクリーンショット 2024-01-31 21 38 50" src="https://github.com/dinhhuy258/git.nvim/assets/51050458/7baeaa0b-17cd-4316-9b3f-f0f1181c509b">

### git diff

<img width="1436" alt="スクリーンショット 2024-01-31 21 40 31" src="https://github.com/dinhhuy258/git.nvim/assets/51050458/6229656a-7b63-493a-9f7c-75b64af9c6e4">