### PR TITLE
Fix url quoting

### DIFF
--- a/lua/git/browse/git_server.lua
+++ b/lua/git/browse/git_server.lua
@@ -19,9 +19,9 @@ function GitServer._open_url(url)
   if vim.fn.has "win16" == 1 or vim.fn.has "win32" == 1 or vim.fn.has "win64" == 1 then
     vim.fn.system("start cmd /cstart /b " .. url)
   elseif vim.fn.has "mac" == 1 or vim.fn.has "macunix" == 1 or vim.fn.has "gui_macvim" == 1 then
-    vim.fn.system('open "' .. url .. '"')
+    vim.fn.system("open '" .. url .. "'")
   else
-    vim.fn.system('xdg-open "' .. url .. '" &> /dev/null &')
+    vim.fn.system("xdg-open '" .. url .. "'' &> /dev/null &")
   end
 end
 


### PR DESCRIPTION
Thank you for building this fantastic plugin!

I’m using [TanStack Router’s file-based routing](https://tanstack.com/router/latest/docs/framework/react/routing/file-based-routing#directory-routes)—which uses $-prefixed file names (e.g. `$userId.tsx`) to denote dynamic segments—so it’s essential that $ in my source-file names be preserved literally.

Currently, wrapping the URL in double quotes causes the shell to expand $userId to empty, yielding:

- Expected: `https://github.com//xxx/yyy/blob/main/$userId.tsx`
- Actual: `https://github.com/xxx/yyy/blob/main/.tsx`

This PR switches those open/xdg-open calls to single-quote quoting around the URL, ensuring any $ in the file name is passed through verbatim and the correct GitHub URL is opened—without affecting other workflows.